### PR TITLE
Add Dockerfile and Taskfile for MTL toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Self-contained MTL toolchain image.
+#
+# Built into the image (the tools are 32-bit / -m32, so the image is pinned to
+# amd64 and runs emulated on Apple Silicon — fine for small one-shot tools):
+#   /src/mtl_compiler, /src/mtl_simu   the binaries
+#   /src/config.txt                    simulator defaults (SOURCE/MAC/BOOT)
+#   /src/nominal.mtl                   the bundled sample app
+# So `mtl:simulate` (cwd = /src) runs out of the box with no host-side config.
+# At runtime your working tree mounts at /work; pass app sources as /work/<file>.
+#
+# Only the build inputs and the two runtime files are COPYed in explicitly, so
+# host artifacts (obj/, *.o, prebuilt binaries) never enter the image — no
+# .dockerignore needed.
+FROM --platform=linux/amd64 debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        g++-multilib \
+        make \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+# Build inputs (objects land in obj/, kept out of src/ and inc/).
+COPY Makefile ./
+COPY inc/ inc/
+COPY src/ src/
+RUN make comp simu
+
+# Runtime defaults read from cwd = /src by the simulator.
+COPY config.txt ./

--- a/README.md
+++ b/README.md
@@ -30,3 +30,62 @@ For full options:
 ## Compiler
 
     ./mtl_compiler [-s] source output
+
+Without `-s` the compiler writes raw bytecode, which is what the simulator
+loads. With `-s` it *signs* the output for the real device's flash format:
+it prepends the magic `amber` (5 bytes) followed by the bytecode size as an
+8-char hex string, and appends the `Mind` footer (4 bytes).
+
+# Utilities
+
+## `utils/correct_const.sh`
+
+The compiler warns when a `var` is only assigned once, at its declaration:
+
+    <name> is only set once, at declaration. It should be a const.
+
+This script applies those fixes in bulk. Capture the compile output to a log,
+then run:
+
+    ./utils/correct_const.sh <compile_log> <source.mtl> <corrected.mtl>
+
+It greps the log for the warning, rewrites each matching `var X` to `const X`
+in `<source.mtl>`, and writes the result to `<corrected.mtl>` (the source is
+left untouched).
+
+**Review the changes by hand** — some single-assignment variables should be an
+enum type rather than a `const`, which the script can't tell apart.
+
+# Docker / Task workflow
+
+If you don't want a 32-bit toolchain on your host, run everything in a
+container. This needs only [Docker](https://docs.docker.com/get-docker/) and
+[Task](https://taskfile.dev/installation/) — no `g++-multilib`, no 32-bit libs.
+
+The image is pinned to `linux/amd64` (the tools are `-m32`); on Apple Silicon
+it runs under emulation, which is fine for these one-shot tools. It is built
+automatically the first time you run a task, and bakes in the binaries plus the
+default `config.txt` and `nominal.mtl`.
+
+List the tasks:
+
+    task --list
+
+## Compile
+
+    task compile SOURCE=app.mtl                 # → app.bin (signed, next to app.mtl)
+    task compile SOURCE=app.mtl OUT=fw.bin      # override the output name
+    task compile SOURCE=app.mtl SIGN=false      # raw bytecode (for the simulator)
+
+`SOURCE` is mounted into the container and the output is written back beside it
+on the host. Output is **signed** by default (`-s`, the device flash format —
+see above); pass `SIGN=false` for raw bytecode such as the simulator loads.
+
+## Simulate
+
+    task simulate SOURCE=app.mtl                    # run app.mtl in the simulator
+    task simulate SOURCE=app.mtl -- --mac 0013...   # pass extra mtl_simu options after --
+
+The simulator runs in the foreground; stop it with a single `Ctrl+C` (the
+container uses `--init` so the signal reaches the simulator). Anything after
+`--` is forwarded verbatim to `mtl_simu` (see `./mtl_simu -h` for options).

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,34 @@
+version: '3'
+
+vars:
+  IMAGE: mtl_linux
+  DIR: .
+
+tasks:
+  image:
+    internal: true   # built on demand as a dep; rebuilt when the toolchain/config changes
+    cmds:
+      - docker build -t {{.IMAGE}} {{.DIR}}
+
+  compile:
+    desc: 'Compile MTL source → bytecode.  Usage: task mtl:compile SOURCE=<src.mtl> [OUT=<out.bin>] [SIGN=false]'
+    deps: [image]
+    requires:
+      vars: [SOURCE]
+    vars:
+      OUT: '{{.OUT | default (printf "%s.bin" (trimSuffix ".mtl" (base .SOURCE)))}}'
+      SIGN: '{{.SIGN | default "true"}}'   # signed device-flash format by default; SIGN=false for raw bytecode
+    cmds:
+      # mount SOURCE's dir at /work so the input is read and the output is written back to the host; tools live at /src
+      # compiler args are positional: [-s] source output
+      - 'docker run --rm -v "$(dirname $(realpath {{.SOURCE}})):/work" {{.IMAGE}} /src/mtl_compiler {{if eq .SIGN "true"}}-s {{end}}/work/{{base .SOURCE}} /work/{{.OUT}}'
+
+  simulate:
+    desc: 'Run an MTL app in the simulator (config baked in).  Usage: task mtl:simulate SOURCE=<app>.mtl [-- extra args]'
+    deps: [image]
+    requires:
+      vars: [SOURCE]
+    cmds:
+      # cwd = /src so the baked config.txt is found; SOURCE is mounted into /work and passed via --source.
+      # --init: run tini as PID 1 so the sim (no SIGINT handler) is a child and a single Ctrl+C stops it.
+      - 'docker run --rm --init -v "$(dirname $(realpath {{.SOURCE}})):/work" {{.IMAGE}} /src/mtl_simu --source /work/{{base .SOURCE}} {{.CLI_ARGS}}'


### PR DESCRIPTION
Introduce a self-contained Docker image and Taskfile to build and run the MTL toolchain + Document  udpates in README